### PR TITLE
Provide more info when .sass-lint.yml is missing

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -38,7 +38,14 @@ module.exports =
         config = if @configPath is '' then findFile filePath, configExt else path.join @configPath, configExt
         linter = require(@executablePath)
 
-        if config is null then throw new Error 'No .sass-lint.yml config file found'
+        if config is null
+          atom.notifications.addError """
+            **No .sass-lint.yml config file found.** You can find an example
+            [here](https://github.com/sasstools/sass-lint/blob/master/lib/config/sass-lint.yml)
+            and documentation on how to configure this and also documentation on
+            each of the rules [here](https://github.com/sasstools/sass-lint/tree/develop/docs).
+          """
+          return []
 
         results = linter.lintFiles(filePath, {}, config)
 


### PR DESCRIPTION
Add more information in the error message when .sass-lint.yml is missing.

![screen shot 2015-10-12 at 01 04 31](https://cloud.githubusercontent.com/assets/423234/10419631/53ae3fb2-707d-11e5-9449-4f76e1d2bfb7.png)

The text is taken from the [readme](https://github.com/DanPurdy/linter-sass-lint#sass-lintyml).
