### PR TITLE
Fix empty files

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -79,7 +79,7 @@ module.exports =
 
           return []
 
-        return results[0].messages.map (msg) ->
+        if results[0] then return results[0].messages.map (msg) ->
           line = if msg.line then msg.line - 1 else 0
           col = if msg.column then msg.column - 1 else 0
 
@@ -87,3 +87,5 @@ module.exports =
           text: if msg.message then msg.ruleId + ': ' + msg.message else 'Unknown Error'
           filePath: filePath
           range: [[line, col], [line, col + 1]]
+
+        return []

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linter-sass-lint",
   "main": "./lib/main",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Atom Linter plugin - Lint your Sass/SCSS with pure node sass-lint",
   "repository": "https://github.com/DanPurdy/linter-sass-lint",
   "license": "MIT",


### PR DESCRIPTION
Fixes an issue that may arise if you were to try linting in an ignored file.

This will become more relevant when ignored files actually work in sass-lint 1.3.2
