### PR TITLE
Release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.4.2
+- Small update to bump minimum sass-lint version to v1.4.0
+
 ### 0.4.1
 - Fixed a possible error that would cause sass-lint to break if you tried to lint in an ignored file
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "atom": ">=1.0.0"
   },
   "dependencies": {
-    "sass-lint": "^1.3.1",
+    "sass-lint": "^1.4.0",
     "atom-linter": "^3.2.0"
   },
   "providedServices": {


### PR DESCRIPTION
Release 0.4.1

Bump our sass-lint dependency. 

Not necessarily needed but means we can force an update to all users to ensure they get the latest fixes and updates
